### PR TITLE
가계부 메인 페이지 추가

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -3464,6 +3464,11 @@
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
+    "browser-cookies": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/browser-cookies/-/browser-cookies-1.2.0.tgz",
+      "integrity": "sha1-/KP/ubamOq3E2MCZnGtX0Pp9KbU="
+    },
     "browser-process-hrtime": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "@types/react-dom": "17.0.0",
     "@types/react-router-dom": "^5.1.7",
     "axios": "^0.21.1",
+    "browser-cookies": "1.2.0",
     "lodash.debounce": "^4.0.8",
     "node-sass": "^4.14.1",
     "react": "17.0.1",

--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -9,18 +9,10 @@ export default function Routes() {
   return (
     <BrowserRouter>
       <Switch>
-        <Route path="/" exact>
-          <PayBooks/>
-        </Route>
-        <Route path="/sign-in">
-          <SignIn/>
-        </Route>
-        <Route path="/sign-up">
-          <SignUp/>
-        </Route>
-        <Route path={"/admin/codes"}>
-          <AdminCodes/>
-        </Route>
+        <Route path="/" exact component={PayBooks} />
+        <Route path="/sign-in" component={SignIn} />
+        <Route path="/sign-up" component={SignUp} />
+        <Route path={"/admin/codes"} component={AdminCodes}/>
         <Route path="*">
           <div>404</div>
         </Route>

--- a/client/src/api/payBooks.ts
+++ b/client/src/api/payBooks.ts
@@ -1,0 +1,14 @@
+import {ICreatePayBookInfo} from "../interfaces/IPayBooks";
+import Axios from "./axios";
+
+const PAY_BOOKS_PREFIX:string = `/api/pay-books`;
+
+export const createPayBookApi = async (data: ICreatePayBookInfo) => {
+    const axios = new Axios<ICreatePayBookInfo>();
+    return axios.post(PAY_BOOKS_PREFIX, data)
+}
+
+export const createPayBookByInvitedCodeApi = async (inviteCode: string) => {
+    const axios = new Axios<{inviteCode: string}>();
+    return axios.post(`${PAY_BOOKS_PREFIX}/invite`, {inviteCode});
+}

--- a/client/src/containers/admin/codes/index.tsx
+++ b/client/src/containers/admin/codes/index.tsx
@@ -6,6 +6,7 @@ import {ICode, IGetCodesApi, IModalCode} from "../../../interfaces/ICodes";
 import {CodeDataKeys, CodeTypes} from "../../../enum/codes";
 import {addCodeApi, updateCodeApi} from "../../../api/codes";
 import useConfirm from "../../../hooks/useConfirm";
+import {Icons} from "../../../enum/icons";
 
 const initialCodeData: IModalCode = {
     code: "",
@@ -169,7 +170,7 @@ const AdminCodes: React.FC = () => {
                 onClose={initializeCode}
                 size={"tiny"}
             >
-                <Header icon='archive' content={`${code?.id ? '코드 수정' : '코드 추가'}`} />
+                <Header icon={Icons.ARCHIVE} content={`${code?.id ? '코드 수정' : '코드 추가'}`} />
                 <Modal.Content className={"AdminCodesModalContent"}>
                     <Form>
                         <Form.Field inline>

--- a/client/src/containers/payBooks/index.tsx
+++ b/client/src/containers/payBooks/index.tsx
@@ -1,10 +1,234 @@
-import React from 'react';
+import React, {SyntheticEvent, useMemo, useState} from 'react';
 import "../../styles/payBooks/index.scss"
+import {Button, ButtonProps, Dropdown, Form, Header, Icon, Input, Modal} from "semantic-ui-react";
+import useRequest from "../../utils/swr";
+import {Icons} from "../../enum/icons";
+import {ICreatePayBookInfo, IGetPayBookApi, IPayBookDropDown} from "../../interfaces/IPayBooks";
+import {DropdownProps} from "semantic-ui-react/dist/commonjs/modules/Dropdown/Dropdown";
+import {CreatedPayBookKeys, SelectedPayBookTypes} from "../../enum/payBooks";
+import {CheckboxProps} from "semantic-ui-react/dist/commonjs/modules/Checkbox/Checkbox";
+import generateUniqueString from "../../utils/generateUniqueString";
+import {createPayBookApi, createPayBookByInvitedCodeApi} from "../../api/payBooks";
+import useConfirm from "../../hooks/useConfirm";
+import {RouteComponentProps} from "react-router-dom"
+import cookies from "browser-cookies";
+import {CookieNames} from "../../enum/cookies";
 
-const PayBooks: React.FC = () => {
+const initialCreatedPayBookInfo: ICreatePayBookInfo = {name: "", isShare: false, inviteCode: ""};
+
+const PayBooks: React.FC<RouteComponentProps> = props => {
+    const {data, mutate} = useRequest<IGetPayBookApi[]>({url: "/api/pay-books"});
+    const [selectedPayBookType, setSelectedPayBookType] = useState<SelectedPayBookTypes>(undefined);
+    const [isOpenSelectTypeModal, setIsOpenSelectTypeModal] = useState<boolean>(false);
+    const [invitedCode, setInvitedCode] = useState<string>("");
+    const [createPayBookInfo, setCreatePayBookInfo] = useState<ICreatePayBookInfo>(initialCreatedPayBookInfo);
+    const { confirmModal, ModalConfirm } = useConfirm();
+
+    const dropDownOptions: IPayBookDropDown[] = useMemo(() => {
+        return data?.map(payBook => ({
+            key: payBook.id,
+            value: payBook.id,
+            text: payBook.name,
+            icon: payBook.isShare ? Icons.USERS : Icons.USER
+        })) ?? []
+    }, [data]);
+
+    const selectPayBook = (e: SyntheticEvent<HTMLElement>, dropDownProps: DropdownProps): void => {
+        cookies.set(CookieNames.PAY_BOOK_ID, String(dropDownProps.value));
+        props.history.push('/histories')
+    }
+
+    const initializeSelectedPayBookType = (initializeModalInfoFn?: () => void) => {
+        if (initializeModalInfoFn) initializeModalInfoFn();
+        setSelectedPayBookType(undefined);
+    }
+
+    const toggleSelectTypeModal = () => {
+        if (isOpenSelectTypeModal) initializeSelectedPayBookType();
+        setIsOpenSelectTypeModal(state => !state);
+    }
+
+    const selectPayBookType = (e: React.MouseEvent<HTMLButtonElement>, buttonProps: ButtonProps):void => {
+        setSelectedPayBookType(SelectedPayBookTypes[buttonProps.value]);
+        setIsOpenSelectTypeModal(false);
+    }
+
+    const changeInvitedCode = (e: React.ChangeEvent<HTMLInputElement>):void => {
+        setInvitedCode(e.target.value);
+    }
+
+    const changeCreatedPayBookInfo = (e: React.ChangeEvent<HTMLInputElement>):void => {
+        setCreatePayBookInfo(state => ({...state, [e.target.name]: e.target.value}))
+    }
+
+    const changeCreatedPayBookInfoIsShared = (e: React.FormEvent<HTMLInputElement>, data: CheckboxProps):void => {
+        setCreatePayBookInfo(state => ({...state, isShare: data.value === SelectedPayBookTypes.INVITED, inviteCode: ""}));
+    }
+
+    const changeCreatedPayBookInfoInvitedCode = ():void => {
+        setCreatePayBookInfo(state => ({...state, inviteCode: generateUniqueString()}));
+    }
+
+    const closeCreatePayBookModal = () => {
+        initializeSelectedPayBookType(() => setCreatePayBookInfo(initialCreatedPayBookInfo))
+    }
+
+    const closeInvitedPayBookModal = () => {
+        initializeSelectedPayBookType(() => setInvitedCode(""))
+    }
+
+    const copyToClipBoard = () => {
+        const textAreaElement = document.createElement("textarea");
+        document.body.appendChild(textAreaElement);
+        textAreaElement.value = createPayBookInfo.inviteCode;
+        textAreaElement.select();
+        document.execCommand('copy');
+        document.body.removeChild(textAreaElement);
+    }
+
+    const showCreatePayBookConfirmModal = () => {
+        confirmModal({
+            message: "가계부를 생성하시겠습니까?",
+            onOk: createPayBook
+        });
+    }
+
+    const createPayBook = async (): Promise<void> => {
+        try {
+            await createPayBookApi(createPayBookInfo);
+            closeCreatePayBookModal();
+            await mutate();
+        } catch (e) {
+            alert(e.message)
+        }
+    }
+
+    const showInvitePayBookConfirmModal = () => {
+        confirmModal({
+            message: "공용 가계부를 추가하시겠습니까?",
+            onOk: createPayBookByInvitedCode
+        });
+    }
+
+    const createPayBookByInvitedCode = async (): Promise<void> => {
+        try {
+            await createPayBookByInvitedCodeApi(invitedCode);
+            closeInvitedPayBookModal();
+            await mutate();
+        } catch (e) {
+            alert(e.message)
+        }
+    }
+
+    const {isOpenInvitedPayBookModal, isOpenNewPayBookModal} = useMemo(() => ({
+        isOpenInvitedPayBookModal: selectedPayBookType === SelectedPayBookTypes.INVITED,
+        isOpenNewPayBookModal: selectedPayBookType === SelectedPayBookTypes.NEW
+    }), [selectedPayBookType]);
+
+    const isDisabledCreatePayBook = useMemo(() => {
+        if (!createPayBookInfo.name) return true;
+        return createPayBookInfo.isShare && !createPayBookInfo.inviteCode;
+    }, [createPayBookInfo])
+
     return (
-        <div>
-
+        <div className="payBookContainer">
+            <div className="buttonWrapper">
+                <Button primary fluid onClick={toggleSelectTypeModal}>새로운 가계부 추가 +</Button>
+            </div>
+            <Dropdown
+                placeholder='가계부를 선택하세요.'
+                fluid
+                multiple
+                search
+                selection
+                options={dropDownOptions}
+                onChange={selectPayBook}
+                closeOnChange
+            />
+            <Modal
+                closeIcon
+                open={isOpenSelectTypeModal}
+                onClose={toggleSelectTypeModal}
+                size={"tiny"}
+            >
+                <Header icon={Icons.BOOK} content={`가계부 추가`} />
+                <Modal.Content className={"selectPayBookType"}>
+                    <Button.Group>
+                        <Button primary value={SelectedPayBookTypes.NEW} onClick={selectPayBookType}>새로운 가계부 추가</Button>
+                        <Button.Or />
+                        <Button positive value={SelectedPayBookTypes.INVITED} onClick={selectPayBookType}>초대 코드 입력</Button>
+                    </Button.Group>
+                </Modal.Content>
+            </Modal>
+            <Modal
+                closeIcon
+                open={isOpenNewPayBookModal}
+                onClose={closeCreatePayBookModal}
+                size={"tiny"}
+            >
+                <Header icon={Icons.BOOK} content={`새로운 가계부 추가`} />
+                <Modal.Content className={"createPayBook"}>
+                    <Form>
+                        <Form.Group inline>
+                            <label>가계부 이름</label>
+                            <Input placeholder='이름 입력' value={createPayBookInfo.name} name={CreatedPayBookKeys.NAME} onChange={changeCreatedPayBookInfo}/>
+                        </Form.Group>
+                        <Form.Group inline>
+                            <label>공유 여부</label>
+                            <Form.Radio
+                                label='공유'
+                                value={SelectedPayBookTypes.INVITED}
+                                checked={createPayBookInfo.isShare}
+                                onChange={changeCreatedPayBookInfoIsShared}
+                            />
+                            <Form.Radio
+                                label='비공유'
+                                value={SelectedPayBookTypes.NEW}
+                                checked={!createPayBookInfo.isShare}
+                                onChange={changeCreatedPayBookInfoIsShared}
+                            />
+                        </Form.Group>
+                        {
+                            createPayBookInfo.isShare && (
+                                <Form.Group inline className={"invitedCode"}>
+                                    <label>초대 코드</label>
+                                    <Header as='h3'>{createPayBookInfo.inviteCode}</Header>
+                                    <Button className={"createCode"} onClick={changeCreatedPayBookInfoInvitedCode}>생성</Button>
+                                    <Button onClick={copyToClipBoard}>복사</Button>
+                                </Form.Group>
+                            )
+                        }
+                    </Form>
+                </Modal.Content>
+                <Modal.Actions>
+                    <Button color='red' onClick={closeCreatePayBookModal}>
+                        <Icon name='remove' /> 취소
+                    </Button>
+                    <Button color='green' disabled={isDisabledCreatePayBook} onClick={showCreatePayBookConfirmModal}>
+                        <Icon name='checkmark' /> 저장
+                    </Button>
+                </Modal.Actions>
+            </Modal>
+            <Modal
+                closeIcon
+                open={isOpenInvitedPayBookModal}
+                onClose={closeInvitedPayBookModal}
+                size={"tiny"}
+            >
+                <Header icon={Icons.BOOK} content={`초대 코드 입력`} />
+                <Modal.Content className={""}>
+                    <Input fluid placeholder='초대 코드를 입력해주세요.' value={invitedCode} onChange={changeInvitedCode}/>
+                </Modal.Content>
+                <Modal.Actions>
+                    <Button color='red' onClick={closeInvitedPayBookModal}>
+                        <Icon name='remove' /> 취소
+                    </Button>
+                    <Button color='green' disabled={!invitedCode} onClick={showInvitePayBookConfirmModal}>
+                        <Icon name='checkmark' /> 저장
+                    </Button>
+                </Modal.Actions>
+            </Modal>
+            {ModalConfirm}
         </div>
     )
 };

--- a/client/src/enum/cookies.ts
+++ b/client/src/enum/cookies.ts
@@ -1,0 +1,4 @@
+export enum CookieNames {
+    PAY_BOOK_ID="payBookId",
+    TOKEN="accessToken"
+}

--- a/client/src/enum/icons.ts
+++ b/client/src/enum/icons.ts
@@ -1,0 +1,6 @@
+export enum Icons {
+    USER="user",
+    USERS="users",
+    ARCHIVE="archive",
+    BOOK="book"
+}

--- a/client/src/enum/payBooks.ts
+++ b/client/src/enum/payBooks.ts
@@ -1,0 +1,10 @@
+export enum SelectedPayBookTypes {
+    INVITED="INVITED",
+    NEW="NEW"
+}
+
+export enum CreatedPayBookKeys {
+    NAME="name",
+    IS_SHARE="isShare",
+    INVITED_CODE="invitedCode"
+}

--- a/client/src/hooks/useConfirm.tsx
+++ b/client/src/hooks/useConfirm.tsx
@@ -31,7 +31,7 @@ export default function useConfirm() {
         </Modal.Content>
         <Modal.Actions>
           <Button basic color="red" inverted onClick={() => setVisible(false)}>
-            <Icon name="remove" /> No
+            <Icon name="remove" /> 취소
           </Button>
           <Button
             color="green"
@@ -41,7 +41,7 @@ export default function useConfirm() {
               confirmModalInfo.onOk();
             }}
           >
-            <Icon name="checkmark" /> Yes
+            <Icon name="checkmark" /> 확인
           </Button>
         </Modal.Actions>
       </Modal>

--- a/client/src/interfaces/IPayBooks.ts
+++ b/client/src/interfaces/IPayBooks.ts
@@ -1,0 +1,23 @@
+import {Icons} from "../enum/icons";
+
+export interface IGetPayBookApi {
+    id: number;
+    name: string;
+    isShare: boolean;
+    inviteCode: string;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface IPayBookDropDown {
+    key: number;
+    value: number;
+    text: string;
+    icon: Icons
+}
+
+export interface ICreatePayBookInfo {
+    name: string;
+    isShare: boolean;
+    inviteCode: string;
+}

--- a/client/src/styles/global.scss
+++ b/client/src/styles/global.scss
@@ -1,2 +1,8 @@
 * {
 }
+
+@media only screen and (max-width: 767px) {
+  .ui.container {
+    width: 100% !important;
+  }
+}

--- a/client/src/styles/payBooks/index.scss
+++ b/client/src/styles/payBooks/index.scss
@@ -1,0 +1,25 @@
+#root {
+  height: 100vh;
+  display: flex;
+  align-items: center;
+
+  .payBookContainer {
+    .buttonWrapper {
+      margin-bottom: 20px;
+    }
+  }
+}
+
+.selectPayBookType {
+  text-align: center;
+}
+
+.createPayBook {
+  .ui.form .inline.fields {
+    align-items: baseline;
+
+    .ui.button.createCode {
+      margin: 0 10px;
+    }
+  }
+}

--- a/client/src/utils/generateUniqueString.ts
+++ b/client/src/utils/generateUniqueString.ts
@@ -1,0 +1,12 @@
+const generateUniqueString = ():string => {
+    const ts:string = String(new Date().getTime())
+    let out:string = '';
+
+    for (let i = 0; i < ts.length; i += 2) {
+        out += Number(ts.substr(i, 2)).toString(36);
+    }
+
+    return out;
+}
+
+export default generateUniqueString;

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": false,
-    "forceConsistentCasingInFileNames": true,
+    "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": true,
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
- 가계부 리스트 조회
- 가계부 선택
   - 선택시 쿠키에 id 가 저장됨. `payBookId` 가 저장되지 않으면 histories API 사용시 에러 발생. 
- 가계부 생성
- 가계부 초대코드로 추가